### PR TITLE
fix(mod/sh/firefox): silence configPath deprecation warning

### DIFF
--- a/modules/shared/home/firefox/default.nix
+++ b/modules/shared/home/firefox/default.nix
@@ -1,5 +1,6 @@
 _: {
   programs.firefox = {
     enable = true;
+    configPath = ".mozilla/firefox";
   };
 }


### PR DESCRIPTION
Sets configPath to legacy ".mozilla/firefox" to match pre-26.05 behavior and suppress the home-manager evaluation warning.