### PR TITLE
fix(dw/podman): docker aliasing on macos and remove podman from shared

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,12 +562,12 @@
         ]
       },
       "locked": {
-        "lastModified": 1779725377,
-        "narHash": "sha256-ULVgU8kJ5M/eOnffrDpaUATDdb8LqzRcdDZsjLlSJ9k=",
-        "rev": "7257b51f5e4f0be165028d5d0670bff4dc19d1d7",
-        "revCount": 189,
+        "lastModified": 1780062390,
+        "narHash": "sha256-ycMWBPqb6tg7snRv8ifJlEJGRR95NIDpDSdlhqGJBCg=",
+        "rev": "f19a086daef100b74592e11fa6dde59e87c661b9",
+        "revCount": 204,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/JHOFER-Cloud/frostplexx-nixkit/0.1.189%2Brev-7257b51f5e4f0be165028d5d0670bff4dc19d1d7/019e604e-d713-7e30-a218-c71ab01350b5/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/JHOFER-Cloud/frostplexx-nixkit/0.1.204%2Brev-f19a086daef100b74592e11fa6dde59e87c661b9/019e73fe-7d2b-7d42-89a4-d6fe1f21408e/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/modules/darwin/system/podman.nix
+++ b/modules/darwin/system/podman.nix
@@ -1,0 +1,20 @@
+{
+  pkgs,
+  vars,
+  ...
+}: {
+  environment.systemPackages = with pkgs; [
+    podman
+    podman-compose
+    podman-mac-helper
+    (writeShellScriptBin "docker" ''exec ${podman}/bin/podman "$@"'')
+  ];
+
+  system.activationScripts.podmanMacHelper.text = ''
+    helper_plist="/Library/LaunchDaemons/com.github.containers.podman.helper-${vars.user.name}.plist"
+    if [ ! -f "$helper_plist" ]; then
+      echo "Installing podman-mac-helper..."
+      ${pkgs.podman-mac-helper}/bin/podman-mac-helper install
+    fi
+  '';
+}

--- a/modules/shared/system/packages.nix
+++ b/modules/shared/system/packages.nix
@@ -36,8 +36,6 @@
     nix-update # https://github.com/Mic92/nix-update
     nixpkgs-review
     nmap
-    podman
-    podman-compose
     progress
     python3
     retry


### PR DESCRIPTION
there is a specific nixos option for this stuff
```nix
virtualisation.podman = {
  enable = true;
  dockerCompat = true;
};
```
